### PR TITLE
Support TLDs other than .co.uk

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ Tools for easily extracting bookmarks and notes in note-friendly formatting.
 ### Audible Book to Player
 From the Audible book page to the web player for that book. This is equivalent to clicking "Play" on the page, with added convenience of it not opening in a new reduced window, allowing bookmarklets to still be available in the main browser window.
 
-<a href='javascript:location.href=location.href.replace(/\?.+/,"").replace(/.co.uk\/.+\//,".co.uk/webplayer?asin=");'>Audible Book to Player</a> <- Drag this to bookmarks bar to use.
-
+Which bookmarklet you will need depends on the top-level domain (TLD) of the Audible site you use.
+- For audible.co.uk: <a href='javascript:location.href=location.href.replace(/\?.+/,"").replace(/.co.uk\/.+\//,".co.uk/webplayer?asin=");'>Audible Book to Player</a> <- Drag this to bookmarks bar to use.
+- For audible.com: <a href='javascript:location.href=location.href.replace(/\?.+/,"").replace(/.com\/.+\//,".com/webplayer?asin=");'>Audible Book to Player</a> <- Drag this to bookmarks bar to use.
+- For other TLDs (eg audible.in, audible.cn), drag the .co.uk one above to bookmarks bar and replace .co.uk with the TLD you use (eg .in, .cn, etc) in both places it occurs.
 
 ### Audible Bookmarks
 From the audible cloud player in browser for the audiobook needed, pause the player (if you want), wait for it to load then click `...` on the page, followed by `Bookmarks` from the list that appears. When your bookmarks then load, click on this bookmarklet, and the notes will be copied to clipboard in a concise markdown format.


### PR DESCRIPTION
Update the README.md bookmarklets to support audible.com and include instructions for other TLDs.

Manually tested for the audible.com one:
1. Saved the bookmarklet
2. Visited a book page and clicked the bookmarklet
<img width="1051" alt="image" src="https://github.com/user-attachments/assets/582500d7-e025-490e-a005-95e5963356ef" />
3. Confirmed that it goes to the right place
<img width="983" alt="image" src="https://github.com/user-attachments/assets/8cf38790-adf8-4909-b2b4-c0fed8507c75" />

What it will look like:
<img width="1707" alt="image" src="https://github.com/user-attachments/assets/2e340162-a8c1-41e1-bb13-57ad88c3be96" />
